### PR TITLE
Added AnimationListener

### DIFF
--- a/demoapp/src/main/java/com/example/demoapp/BaseActivity.java
+++ b/demoapp/src/main/java/com/example/demoapp/BaseActivity.java
@@ -1,8 +1,11 @@
 package com.example.demoapp;
 
+import android.content.Context;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
+import android.widget.Toast;
 
+import com.hanks.htextview.base.AnimationListener;
 import com.hanks.htextview.base.HTextView;
 
 
@@ -36,6 +39,19 @@ public class BaseActivity extends AppCompatActivity {
                 }
                 ((HTextView) v).animateText(sentences[index++]);
             }
+        }
+    }
+
+    class SimpleAnimationListener implements AnimationListener {
+
+        private Context context;
+
+        public SimpleAnimationListener(Context context) {
+            this.context = context;
+        }
+        @Override
+        public void onAnimationEnd(HTextView hTextView) {
+            Toast.makeText(context, "Animation finished", Toast.LENGTH_SHORT).show();
         }
     }
 

--- a/demoapp/src/main/java/com/example/demoapp/EvaporateTextViewActivity.java
+++ b/demoapp/src/main/java/com/example/demoapp/EvaporateTextViewActivity.java
@@ -23,6 +23,11 @@ public class EvaporateTextViewActivity extends BaseActivity {
         textView2.setOnClickListener(new ClickListener());
         textView3.setOnClickListener(new ClickListener());
 
+        textView.setAnimationListener(new SimpleAnimationListener(this));
+        textView1.setAnimationListener(new SimpleAnimationListener(this));
+        textView2.setAnimationListener(new SimpleAnimationListener(this));
+        textView3.setAnimationListener(new SimpleAnimationListener(this));
+
         ((SeekBar) findViewById(R.id.seekbar)).setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
             @Override
             public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {

--- a/demoapp/src/main/java/com/example/demoapp/FadeTextViewActivity.java
+++ b/demoapp/src/main/java/com/example/demoapp/FadeTextViewActivity.java
@@ -17,8 +17,10 @@ public class FadeTextViewActivity extends BaseActivity {
 
         textView = (FadeTextView) findViewById(R.id.textview);
         textView.setOnClickListener(new ClickListener());
+        textView.setAnimationListener(new SimpleAnimationListener(this));
         textview2 = (FadeTextView) findViewById(R.id.textview2);
         textview2.setOnClickListener(new ClickListener());
+        textview2.setAnimationListener(new SimpleAnimationListener(this));
 
         seekBar = (SeekBar) findViewById(R.id.seekbar);
         seekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {

--- a/demoapp/src/main/java/com/example/demoapp/FallTextViewActivity.java
+++ b/demoapp/src/main/java/com/example/demoapp/FallTextViewActivity.java
@@ -23,6 +23,11 @@ public class FallTextViewActivity extends BaseActivity {
         textView2.setOnClickListener(new ClickListener());
         textView3.setOnClickListener(new ClickListener());
 
+        textView.setAnimationListener(new SimpleAnimationListener(this));
+        textView1.setAnimationListener(new SimpleAnimationListener(this));
+        textView2.setAnimationListener(new SimpleAnimationListener(this));
+        textView3.setAnimationListener(new SimpleAnimationListener(this));
+
         ((SeekBar) findViewById(R.id.seekbar)).setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
             @Override
             public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {

--- a/demoapp/src/main/java/com/example/demoapp/LineTextViewActivity.java
+++ b/demoapp/src/main/java/com/example/demoapp/LineTextViewActivity.java
@@ -1,8 +1,6 @@
 package com.example.demoapp;
 
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
-import android.view.View;
 import android.widget.SeekBar;
 
 import com.hanks.htextview.line.LineTextView;
@@ -19,14 +17,19 @@ public class LineTextViewActivity extends BaseActivity {
 
         hTextView = (LineTextView) findViewById(R.id.textview);
         hTextView.setOnClickListener(new ClickListener());
+        hTextView.setAnimationListener(new SimpleAnimationListener(this));
 
         hTextView2 = (LineTextView) findViewById(R.id.textview2);
         hTextView2.setOnClickListener(new ClickListener());
+        hTextView2.setAnimationListener(new SimpleAnimationListener(this));
 
         hTextView3 = (LineTextView) findViewById(R.id.textview3);
         hTextView3.setOnClickListener(new ClickListener());
+        hTextView3.setAnimationListener(new SimpleAnimationListener(this));
+
         hTextView4 = (LineTextView) findViewById(R.id.textview4);
         hTextView4.setOnClickListener(new ClickListener());
+        hTextView4.setAnimationListener(new SimpleAnimationListener(this));
 
         seekBar = (SeekBar) findViewById(R.id.seekbar);
         seekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {

--- a/demoapp/src/main/java/com/example/demoapp/ScaleTextViewActivity.java
+++ b/demoapp/src/main/java/com/example/demoapp/ScaleTextViewActivity.java
@@ -23,6 +23,11 @@ public class ScaleTextViewActivity extends BaseActivity {
         textView2.setOnClickListener(new ClickListener());
         textView3.setOnClickListener(new ClickListener());
 
+        textView.setAnimationListener(new SimpleAnimationListener(this));
+        textView1.setAnimationListener(new SimpleAnimationListener(this));
+        textView2.setAnimationListener(new SimpleAnimationListener(this));
+        textView3.setAnimationListener(new SimpleAnimationListener(this));
+
         ((SeekBar) findViewById(R.id.seekbar)).setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
             @Override
             public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {

--- a/demoapp/src/main/java/com/example/demoapp/TyperTextViewActivity.java
+++ b/demoapp/src/main/java/com/example/demoapp/TyperTextViewActivity.java
@@ -2,13 +2,20 @@ package com.example.demoapp;
 
 import android.os.Bundle;
 
+import com.hanks.htextview.base.HTextView;
+
 public class TyperTextViewActivity extends BaseActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_typer_text_view);
-        findViewById(R.id.textview).setOnClickListener(new ClickListener());
-        findViewById(R.id.textview2).setOnClickListener(new ClickListener());
+        final HTextView textView1 = (HTextView) findViewById(R.id.textview);
+        textView1.setOnClickListener(new ClickListener());
+        textView1.setAnimationListener(new SimpleAnimationListener(this));
+
+        final HTextView textView2 = (HTextView) findViewById(R.id.textview2);
+        textView2.setOnClickListener(new ClickListener());
+        textView2.setAnimationListener(new SimpleAnimationListener(this));
     }
 }

--- a/htextview-base/src/main/java/com/hanks/htextview/base/AnimationListener.java
+++ b/htextview-base/src/main/java/com/hanks/htextview/base/AnimationListener.java
@@ -1,0 +1,9 @@
+package com.hanks.htextview.base;
+
+/**
+ *
+ */
+
+public interface AnimationListener {
+    void onAnimationEnd(HTextView hTextView);
+}

--- a/htextview-base/src/main/java/com/hanks/htextview/base/DefaultAnimatorListener.java
+++ b/htextview-base/src/main/java/com/hanks/htextview/base/DefaultAnimatorListener.java
@@ -1,0 +1,29 @@
+package com.hanks.htextview.base;
+
+import android.animation.Animator;
+
+/**
+ *
+ */
+
+public class DefaultAnimatorListener implements Animator.AnimatorListener {
+    @Override
+    public void onAnimationStart(Animator animation) {
+        // no-op
+    }
+
+    @Override
+    public void onAnimationEnd(Animator animation) {
+        // no-op
+    }
+
+    @Override
+    public void onAnimationCancel(Animator animation) {
+        // no-op
+    }
+
+    @Override
+    public void onAnimationRepeat(Animator animation) {
+        // no-op
+    }
+}

--- a/htextview-base/src/main/java/com/hanks/htextview/base/HText.java
+++ b/htextview-base/src/main/java/com/hanks/htextview/base/HText.java
@@ -25,6 +25,7 @@ public abstract class HText implements IHText {
     protected float progress; // 0 ~ 1
     protected float mTextSize;
     protected float oldStartX = 0;
+    protected AnimationListener animationListener;
 
     public void setProgress(float progress) {
         this.progress = progress;
@@ -85,6 +86,11 @@ public abstract class HText implements IHText {
         prepareAnimate();
         animatePrepare(text);
         animateStart(text);
+    }
+
+    @Override
+    public void setAnimationListener(AnimationListener listener) {
+        animationListener = listener;
     }
 
     @Override

--- a/htextview-base/src/main/java/com/hanks/htextview/base/HTextView.java
+++ b/htextview-base/src/main/java/com/hanks/htextview/base/HTextView.java
@@ -22,6 +22,8 @@ public abstract class HTextView extends TextView {
         super(context, attrs, defStyleAttr);
     }
 
+    public abstract void setAnimationListener(AnimationListener listener);
+
     public abstract void setProgress(float progress);
 
     public abstract void animateText(CharSequence text);

--- a/htextview-base/src/main/java/com/hanks/htextview/base/IHText.java
+++ b/htextview-base/src/main/java/com/hanks/htextview/base/IHText.java
@@ -13,4 +13,6 @@ public interface IHText {
     void animateText(CharSequence text);
 
     void onDraw(Canvas canvas);
+
+    void setAnimationListener(AnimationListener listener);
 }

--- a/htextview-evaporate/src/main/java/com/hanks/htextview/evaporate/EvaporateText.java
+++ b/htextview-evaporate/src/main/java/com/hanks/htextview/evaporate/EvaporateText.java
@@ -1,5 +1,6 @@
 package com.hanks.htextview.evaporate;
 
+import android.animation.Animator;
 import android.animation.ValueAnimator;
 import android.graphics.Canvas;
 import android.graphics.Rect;
@@ -8,6 +9,7 @@ import android.view.animation.AccelerateDecelerateInterpolator;
 
 import com.hanks.htextview.base.CharacterDiffResult;
 import com.hanks.htextview.base.CharacterUtils;
+import com.hanks.htextview.base.DefaultAnimatorListener;
 import com.hanks.htextview.base.HText;
 import com.hanks.htextview.base.HTextView;
 
@@ -30,10 +32,18 @@ public class EvaporateText extends HText {
     private ValueAnimator animator;
 
     @Override
-    public void init(HTextView hTextView, AttributeSet attrs, int defStyle) {
+    public void init(final HTextView hTextView, AttributeSet attrs, int defStyle) {
         super.init(hTextView, attrs, defStyle);
         animator = new ValueAnimator();
         animator.setInterpolator(new AccelerateDecelerateInterpolator());
+        animator.addListener(new DefaultAnimatorListener() {
+            @Override
+            public void onAnimationEnd(Animator animation) {
+                if(animationListener != null) {
+                    animationListener.onAnimationEnd(mHTextView);
+                }
+            }
+        });
         animator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
             @Override
             public void onAnimationUpdate(ValueAnimator animation) {

--- a/htextview-evaporate/src/main/java/com/hanks/htextview/evaporate/EvaporateTextView.java
+++ b/htextview-evaporate/src/main/java/com/hanks/htextview/evaporate/EvaporateTextView.java
@@ -5,6 +5,7 @@ import android.graphics.Canvas;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 
+import com.hanks.htextview.base.AnimationListener;
 import com.hanks.htextview.base.HTextView;
 
 /**
@@ -27,6 +28,11 @@ public class EvaporateTextView extends HTextView {
     public EvaporateTextView(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
         init(attrs, defStyleAttr);
+    }
+
+    @Override
+    public void setAnimationListener(AnimationListener listener) {
+        evaporateText.setAnimationListener(listener);
     }
 
     private void init(AttributeSet attrs, int defStyleAttr) {

--- a/htextview-fade/src/main/java/com/hanks/htextview/fade/FadeText.java
+++ b/htextview-fade/src/main/java/com/hanks/htextview/fade/FadeText.java
@@ -1,5 +1,6 @@
 package com.hanks.htextview.fade;
 
+import android.animation.Animator;
 import android.animation.ValueAnimator;
 import android.content.res.TypedArray;
 import android.graphics.Canvas;
@@ -7,6 +8,7 @@ import android.text.Layout;
 import android.util.AttributeSet;
 import android.view.animation.LinearInterpolator;
 
+import com.hanks.htextview.base.DefaultAnimatorListener;
 import com.hanks.htextview.base.HText;
 import com.hanks.htextview.base.HTextView;
 
@@ -76,6 +78,14 @@ public class FadeText extends HText {
         ValueAnimator valueAnimator = ValueAnimator.ofFloat(0, 1)
                 .setDuration((long) animationDuration);
         valueAnimator.setInterpolator(new LinearInterpolator());
+        valueAnimator.addListener(new DefaultAnimatorListener() {
+            @Override
+            public void onAnimationEnd(Animator animation) {
+                if(animationListener != null) {
+                    animationListener.onAnimationEnd(mHTextView);
+                }
+            }
+        });
         valueAnimator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
             @Override
             public void onAnimationUpdate(ValueAnimator animation) {

--- a/htextview-fade/src/main/java/com/hanks/htextview/fade/FadeTextView.java
+++ b/htextview-fade/src/main/java/com/hanks/htextview/fade/FadeTextView.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.graphics.Canvas;
 import android.util.AttributeSet;
 
+import com.hanks.htextview.base.AnimationListener;
 import com.hanks.htextview.base.HTextView;
 
 
@@ -26,6 +27,11 @@ public class FadeTextView extends HTextView {
     public FadeTextView(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
         init(attrs, defStyleAttr);
+    }
+
+    @Override
+    public void setAnimationListener(AnimationListener listener) {
+        fadeText.setAnimationListener(listener);
     }
 
     private void init(AttributeSet attrs, int defStyleAttr) {

--- a/htextview-fall/src/main/java/com/hanks/htextview/fall/FallText.java
+++ b/htextview-fall/src/main/java/com/hanks/htextview/fall/FallText.java
@@ -1,5 +1,6 @@
 package com.hanks.htextview.fall;
 
+import android.animation.Animator;
 import android.animation.ValueAnimator;
 import android.graphics.Canvas;
 import android.graphics.Paint;
@@ -11,6 +12,7 @@ import android.view.animation.OvershootInterpolator;
 
 import com.hanks.htextview.base.CharacterDiffResult;
 import com.hanks.htextview.base.CharacterUtils;
+import com.hanks.htextview.base.DefaultAnimatorListener;
 import com.hanks.htextview.base.HText;
 import com.hanks.htextview.base.HTextView;
 
@@ -36,6 +38,14 @@ public class FallText extends HText {
         super.init(hTextView, attrs, defStyle);
         animator = new ValueAnimator();
         animator.setInterpolator(new AccelerateDecelerateInterpolator());
+        animator.addListener(new DefaultAnimatorListener() {
+            @Override
+            public void onAnimationEnd(Animator animation) {
+                if(animationListener != null) {
+                    animationListener.onAnimationEnd(mHTextView);
+                }
+            }
+        });
         animator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
             @Override
             public void onAnimationUpdate(ValueAnimator animation) {

--- a/htextview-fall/src/main/java/com/hanks/htextview/fall/FallTextView.java
+++ b/htextview-fall/src/main/java/com/hanks/htextview/fall/FallTextView.java
@@ -5,6 +5,7 @@ import android.graphics.Canvas;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 
+import com.hanks.htextview.base.AnimationListener;
 import com.hanks.htextview.base.HTextView;
 
 /**
@@ -26,6 +27,11 @@ public class FallTextView extends HTextView {
     public FallTextView(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
         init(attrs, defStyleAttr);
+    }
+
+    @Override
+    public void setAnimationListener(AnimationListener listener) {
+        fallText.setAnimationListener(listener);
     }
 
     private void init(AttributeSet attrs, int defStyleAttr) {

--- a/htextview-line/src/main/java/com/hanks/htextview/line/LineText.java
+++ b/htextview-line/src/main/java/com/hanks/htextview/line/LineText.java
@@ -1,5 +1,6 @@
 package com.hanks.htextview.line;
 
+import android.animation.Animator;
 import android.animation.ValueAnimator;
 import android.content.res.TypedArray;
 import android.graphics.Canvas;
@@ -8,6 +9,7 @@ import android.graphics.PointF;
 import android.util.AttributeSet;
 import android.view.animation.LinearInterpolator;
 
+import com.hanks.htextview.base.DefaultAnimatorListener;
 import com.hanks.htextview.base.DisplayUtils;
 import com.hanks.htextview.base.HText;
 import com.hanks.htextview.base.HTextView;
@@ -83,6 +85,14 @@ public class LineText extends HText {
         ValueAnimator valueAnimator = ValueAnimator.ofFloat(0, 1)
                 .setDuration((long) animationDuration);
         valueAnimator.setInterpolator(new LinearInterpolator());
+        valueAnimator.addListener(new DefaultAnimatorListener() {
+            @Override
+            public void onAnimationEnd(Animator animation) {
+                if(animationListener != null) {
+                    animationListener.onAnimationEnd(mHTextView);
+                }
+            }
+        });
         valueAnimator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
             @Override
             public void onAnimationUpdate(ValueAnimator animation) {

--- a/htextview-line/src/main/java/com/hanks/htextview/line/LineTextView.java
+++ b/htextview-line/src/main/java/com/hanks/htextview/line/LineTextView.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.graphics.Canvas;
 import android.util.AttributeSet;
 
+import com.hanks.htextview.base.AnimationListener;
 import com.hanks.htextview.base.HTextView;
 
 
@@ -27,6 +28,11 @@ public class LineTextView extends HTextView {
     public LineTextView(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
         init(attrs, defStyleAttr);
+    }
+
+    @Override
+    public void setAnimationListener(AnimationListener listener) {
+        lineText.setAnimationListener(listener);
     }
 
     public void setLineColor(int color) {

--- a/htextview-rainbow/src/main/java/com/hanks/htextview/rainbow/RainbowTextView.java
+++ b/htextview-rainbow/src/main/java/com/hanks/htextview/rainbow/RainbowTextView.java
@@ -8,6 +8,7 @@ import android.graphics.Matrix;
 import android.graphics.Shader;
 import android.util.AttributeSet;
 
+import com.hanks.htextview.base.AnimationListener;
 import com.hanks.htextview.base.DisplayUtils;
 import com.hanks.htextview.base.HTextView;
 
@@ -36,6 +37,11 @@ public class RainbowTextView extends HTextView {
     public RainbowTextView(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
         init(attrs, defStyleAttr);
+    }
+
+    @Override
+    public void setAnimationListener(AnimationListener listener) {
+        throw new UnsupportedOperationException("Invalid operation for rainbow");
     }
 
     private void init(AttributeSet attrs, int defStyleAttr) {

--- a/htextview-scale/src/main/java/com/hanks/htextview/scale/ScaleText.java
+++ b/htextview-scale/src/main/java/com/hanks/htextview/scale/ScaleText.java
@@ -1,5 +1,6 @@
 package com.hanks.htextview.scale;
 
+import android.animation.Animator;
 import android.animation.ValueAnimator;
 import android.graphics.Canvas;
 import android.util.AttributeSet;
@@ -7,6 +8,7 @@ import android.view.animation.AccelerateDecelerateInterpolator;
 
 import com.hanks.htextview.base.CharacterDiffResult;
 import com.hanks.htextview.base.CharacterUtils;
+import com.hanks.htextview.base.DefaultAnimatorListener;
 import com.hanks.htextview.base.HText;
 import com.hanks.htextview.base.HTextView;
 
@@ -31,6 +33,14 @@ public class ScaleText extends HText {
         super.init(hTextView, attrs, defStyle);
         animator = new ValueAnimator();
         animator.setInterpolator(new AccelerateDecelerateInterpolator());
+        animator.addListener(new DefaultAnimatorListener() {
+            @Override
+            public void onAnimationEnd(Animator animation) {
+                if(animationListener != null) {
+                    animationListener.onAnimationEnd(mHTextView);
+                }
+            }
+        });
         animator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
             @Override
             public void onAnimationUpdate(ValueAnimator animation) {

--- a/htextview-scale/src/main/java/com/hanks/htextview/scale/ScaleTextView.java
+++ b/htextview-scale/src/main/java/com/hanks/htextview/scale/ScaleTextView.java
@@ -5,6 +5,7 @@ import android.graphics.Canvas;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 
+import com.hanks.htextview.base.AnimationListener;
 import com.hanks.htextview.base.HTextView;
 
 /**
@@ -30,6 +31,11 @@ public class ScaleTextView extends HTextView {
         scaleText.init(this, attrs, defStyleAttr);
         setMaxLines(1);
         setEllipsize(TextUtils.TruncateAt.END);
+    }
+
+    @Override
+    public void setAnimationListener(AnimationListener listener) {
+        scaleText.setAnimationListener(listener);
     }
 
     @Override

--- a/htextview-typer/src/main/java/com/hanks/htextview/typer/TyperTextView.java
+++ b/htextview-typer/src/main/java/com/hanks/htextview/typer/TyperTextView.java
@@ -6,6 +6,7 @@ import android.os.Handler;
 import android.os.Message;
 import android.util.AttributeSet;
 
+import com.hanks.htextview.base.AnimationListener;
 import com.hanks.htextview.base.HTextView;
 
 import java.util.Random;
@@ -23,6 +24,7 @@ public class TyperTextView extends HTextView {
     private Handler handler;
     private int charIncrease;
     private int typerSpeed;
+    private AnimationListener animationListener;
 
     public TyperTextView(Context context) {
         this(context, null);
@@ -56,10 +58,19 @@ public class TyperTextView extends HTextView {
                     message.what = INVALIDATE;
                     handler.sendMessageDelayed(message, randomTime);
                     return false;
+                } else {
+                    if(animationListener != null) {
+                        animationListener.onAnimationEnd(TyperTextView.this);
+                    }
                 }
                 return false;
             }
         });
+    }
+
+    @Override
+    public void setAnimationListener(AnimationListener listener) {
+        animationListener = listener;
     }
 
 
@@ -89,6 +100,7 @@ public class TyperTextView extends HTextView {
         if (text == null) {
             throw new RuntimeException("text must not  be null");
         }
+
         mText = text;
         setText("");
         Message message = Message.obtain();


### PR DESCRIPTION
Allows to listen to the end of an animation. (Mentioned in #57)

To add the `AnimationListener` just use the `HTextView.setAnimationListener(AnimationListener)` method. Works for all types, except for rainbow, because this has an endless animation. Setting the listener in rainbow throws an `UnsupportedOperationException`.

DemoApp shows a simple example of how to use the listener. (Just shows a Toast, when the animation has finished).
